### PR TITLE
Fix CMake on OSX 10.10 (Can not find ZLIB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,15 +86,6 @@ ENDIF()
 
 find_package(OpenSSL)
 
-IF(APPLE)
-  # As of 10.10 yosemite, the OpenSSL static libraries shipped with os x have a dependency
-  # on zlib, so any time you link in openssl you also need to link zlib.  .  We really want to detect whether openssl was configured with the --no-zlib
-  # option or not when it was built, but that's difficult to do in practice, so we
-  # just always try to link it in on mac.
-  find_package( ZLIB REQUIRED )
-ENDIF(APPLE)
-
-
 set( CMAKE_FIND_LIBRARY_SUFFIXES ${ORIGINAL_LIB_SUFFIXES} )
 
 option( UNITY_BUILD OFF )
@@ -353,6 +344,14 @@ if(WIN32)
    set_property(TARGET fc PROPERTY SHARED_LIBRARIES_RELEASE ${SHARED_LIBRARIES_RELEASE})
 
 endif(WIN32)
+
+IF(APPLE)
+  # As of 10.10 yosemite, the OpenSSL static libraries shipped with os x have a dependency
+  # on zlib, so any time you link in openssl you also need to link zlib.  .  We really want to detect whether openssl was configured with the --no-zlib
+  # option or not when it was built, but that's difficult to do in practice, so we
+  # just always try to link it in on mac.
+  find_package( ZLIB REQUIRED )
+ENDIF(APPLE)
 
 SET(OPENSSL_CONF_TARGET )
 IF(DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)


### PR DESCRIPTION
https://github.com/BitShares/fc/commit/6ddf1639c5862f25ac3e66a8287a2b820d5183ab

Become ok after revert the position, any comment on this?


```
-- Found OpenSSL: /usr/local/Cellar/openssl/1.0.1i/lib/libssl.a;/usr/local/Cellar/openssl/1.0.1i/lib/libcrypto.a (found version "1.0.1i")
CMake Error at /usr/local/Cellar/cmake/3.1.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:138 (message):
  Could NOT find ZLIB (missing: ZLIB_LIBRARY) (found version "1.2.5")
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.1.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:374 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/Cellar/cmake/3.1.0/share/cmake/Modules/FindZLIB.cmake:110 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  libraries/fc/CMakeLists.txt:94 (find_package)
```